### PR TITLE
INDY-1112: change primeries election procedure for backup instances. …

### DIFF
--- a/plenum/common/stack_manager.py
+++ b/plenum/common/stack_manager.py
@@ -170,14 +170,46 @@ class TxnStackManager(metaclass=ABCMeta):
         nodeOrClientObj.nodestack.maintainConnections(force=True)
 
     def stackHaChanged(self, txn, remoteName, nodeOrClientObj):
-        nodeHa = (txn[DATA][NODE_IP], txn[DATA][NODE_PORT])
-        cliHa = (txn[DATA][CLIENT_IP], txn[DATA][CLIENT_PORT])
+        nodeHa = None
+        cliHa = None
+        if self.isNode:
+            node_ha_changed = False
+            (ip, port) = nodeOrClientObj.nodeReg[remoteName]
+            if NODE_IP in txn[DATA] and ip != txn[DATA][NODE_IP]:
+                ip = txn[DATA][NODE_IP]
+                node_ha_changed = True
+
+            if NODE_PORT in txn[DATA] and port != txn[DATA][NODE_PORT]:
+                port = txn[DATA][NODE_PORT]
+                node_ha_changed = True
+
+            if node_ha_changed:
+                nodeHa = (ip, port)
+
+        cli_ha_changed = False
+        (ip, port) = nodeOrClientObj.cliNodeReg[remoteName + CLIENT_STACK_SUFFIX] \
+            if self.isNode \
+            else nodeOrClientObj.nodeReg[remoteName]
+
+        if CLIENT_IP in txn[DATA] and ip != txn[DATA][CLIENT_IP]:
+            ip = txn[DATA][CLIENT_IP]
+            cli_ha_changed = True
+
+        if CLIENT_PORT in txn[DATA] and port != txn[DATA][CLIENT_PORT]:
+            port = txn[DATA][CLIENT_PORT]
+            cli_ha_changed = True
+
+        if cli_ha_changed:
+            cliHa = (ip, port)
+
         rid = self.removeRemote(nodeOrClientObj.nodestack, remoteName)
         if self.isNode:
-            nodeOrClientObj.nodeReg[remoteName] = HA(*nodeHa)
-            nodeOrClientObj.cliNodeReg[remoteName +
-                                       CLIENT_STACK_SUFFIX] = HA(*cliHa)
-        else:
+            if nodeHa:
+                nodeOrClientObj.nodeReg[remoteName] = HA(*nodeHa)
+            if cliHa:
+                nodeOrClientObj.cliNodeReg[remoteName +
+                                           CLIENT_STACK_SUFFIX] = HA(*cliHa)
+        elif cliHa:
             nodeOrClientObj.nodeReg[remoteName] = HA(*cliHa)
 
         # Attempt connection at the new HA

--- a/plenum/server/node.py
+++ b/plenum/server/node.py
@@ -882,6 +882,9 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
     def get_name_by_rank(self, rank, nodeReg=None):
         return self.poolManager.get_name_by_rank(rank, nodeReg=nodeReg)
 
+    def get_rank_by_name(self, name, nodeReg=None):
+        return self.poolManager.get_rank_by_name(name, nodeReg=nodeReg)
+
     def newViewChanger(self):
         if self.view_changer:
             return self.view_changer
@@ -2354,15 +2357,41 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
         self._schedule_view_change()
 
     def select_primaries(self, nodeReg: Dict[str, HA]=None):
+        primaries = set()
+        primary_rank = None
+        '''
+        Build a set of names of primaries, it is needed to avoid
+        duplicates of primary nodes for different replicas.
+        '''
+        for instance_id, replica in enumerate(self.replicas):
+            if replica.primaryName is not None:
+                name = replica.primaryName.split(":", 1)[0]
+                primaries.add(name)
+                '''
+                Remember the rank of primary of master instance, it is needed
+                for calculation of primaries for backup instances.
+                '''
+                if instance_id == 0:
+                    primary_rank = self.get_rank_by_name(name, nodeReg)
+
         for instance_id, replica in enumerate(self.replicas):
             if replica.primaryName is not None:
                 logger.debug('{} already has a primary'.format(replica))
                 continue
-            new_primary_name = self.elector.next_primary_replica_name(
-                instance_id, nodeReg=nodeReg)
+            if instance_id == 0:
+                new_primary_name, new_primary_instance_name =\
+                    self.elector.next_primary_replica_name_for_master(nodeReg=nodeReg)
+                primary_rank = self.get_rank_by_name(
+                    new_primary_name, nodeReg)
+            else:
+                assert primary_rank is not None
+                new_primary_name, new_primary_instance_name =\
+                    self.elector.next_primary_replica_name_for_backup(
+                        instance_id, primary_rank, primaries, nodeReg=nodeReg)
+            primaries.add(new_primary_name)
             logger.display("{}{} selected primary {} for instance {} (view {})"
                            .format(PRIMARY_SELECTION_PREFIX, replica,
-                                   new_primary_name, instance_id, self.viewNo),
+                                   new_primary_instance_name, instance_id, self.viewNo),
                            extra={"cli": "ANNOUNCE",
                                   "tags": ["node-election"]})
             if instance_id == 0:
@@ -2372,7 +2401,7 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
                 # participating.
                 self.start_participating()
 
-            replica.primaryChanged(new_primary_name)
+            replica.primaryChanged(new_primary_instance_name)
             self.primary_selected(instance_id)
 
             logger.display("{}{} declares view change {} as completed for "
@@ -2383,7 +2412,7 @@ class Node(HasActionQueue, Motor, Propagator, MessageProcessor, HasFileStorage,
                                    replica,
                                    self.viewNo,
                                    instance_id,
-                                   new_primary_name,
+                                   new_primary_instance_name,
                                    self.ledger_summary),
                            extra={"cli": "ANNOUNCE",
                                   "tags": ["node-election"]})

--- a/plenum/server/pool_manager.py
+++ b/plenum/server/pool_manager.py
@@ -177,7 +177,6 @@ class TxnPoolManager(PoolManager, TxnStackManager):
                       ha=HA('0.0.0.0', ha[1]),
                       main=True,
                       auth_mode=AuthMode.RESTRICTED.value)
-        nodeReg[name] = HA(*ha)
 
         cliname = cliname or (name + CLIENT_STACK_SUFFIX)
         if not cliha:
@@ -186,7 +185,6 @@ class TxnPoolManager(PoolManager, TxnStackManager):
                       ha=HA('0.0.0.0', cliha[1]),
                       main=True,
                       auth_mode=AuthMode.ALLOW_ANY.value)
-        cliNodeReg[cliname] = HA(*cliha)
 
         if keys_dir:
             nstack['basedirpath'] = keys_dir
@@ -214,7 +212,7 @@ class TxnPoolManager(PoolManager, TxnStackManager):
         return committedTxns
 
     def onPoolMembershipChange(self, txn):
-        if txn[TXN_TYPE] == NODE:
+        if txn[TXN_TYPE] == NODE and DATA in txn:
             nodeName = txn[DATA][ALIAS]
             nodeNym = txn[TARGET_NYM]
 
@@ -253,10 +251,15 @@ class TxnPoolManager(PoolManager, TxnStackManager):
     def addNewNodeAndConnect(self, txn):
         nodeName = txn[DATA][ALIAS]
         if nodeName == self.name:
-            logger.debug("{} not adding itself to node registry".
+            logger.debug("{} adding itself to node registry".
                          format(self.name))
-            return
-        self.connectNewRemote(txn, nodeName, self.node)
+            self.node.nodeReg[nodeName] = HA(txn[DATA][NODE_IP],
+                                             txn[DATA][NODE_PORT])
+            self.node.cliNodeReg[nodeName + CLIENT_STACK_SUFFIX] = \
+                HA(txn[DATA][CLIENT_IP],
+                   txn[DATA][CLIENT_PORT])
+        else:
+            self.connectNewRemote(txn, nodeName, self.node, nodeName != self.name)
         self.node.nodeJoined(txn)
 
     def node_about_to_be_disconnected(self, nodeName):
@@ -269,6 +272,33 @@ class TxnPoolManager(PoolManager, TxnStackManager):
         # TODO: Check if new HA is same as old HA and only update if
         # new HA is different.
         if nodeName == self.name:
+            # Update itself in node registry if needed
+            ha_changed = False
+            (ip, port) = self.node.nodeReg[nodeName]
+            if NODE_IP in txn[DATA] and ip != txn[DATA][NODE_IP]:
+                ip = txn[DATA][NODE_IP]
+                ha_changed = True
+
+            if NODE_PORT in txn[DATA] and port != txn[DATA][NODE_PORT]:
+                port = txn[DATA][NODE_PORT]
+                ha_changed = True
+
+            if ha_changed:
+                self.node.nodeReg[nodeName] = HA(ip, port)
+
+            ha_changed = False
+            (ip, port) = self.node.cliNodeReg[nodeName + CLIENT_STACK_SUFFIX]
+            if CLIENT_IP in txn[DATA] and ip != txn[DATA][CLIENT_IP]:
+                ip = txn[DATA][CLIENT_IP]
+                ha_changed = True
+
+            if CLIENT_PORT in txn[DATA] and port != txn[DATA][CLIENT_PORT]:
+                port = txn[DATA][CLIENT_PORT]
+                ha_changed = True
+
+            if ha_changed:
+                self.node.cliNodeReg[nodeName + CLIENT_STACK_SUFFIX] = HA(ip, port)
+
             self.node.nodestack.onHostAddressChanged()
             self.node.clientstack.onHostAddressChanged()
         else:
@@ -411,6 +441,11 @@ class TxnPoolManager(PoolManager, TxnStackManager):
             return None
         return self._get_rank(node_id, self.node_ids_ordered_by_rank(nodeReg))
 
+    def get_rank_by_name(self, name, nodeReg=None) -> Optional[int]:
+        for nym, nm in self._ordered_node_ids.items():
+            if name == nm:
+                return self.get_rank_of(nym, nodeReg)
+
     def get_name_by_rank(self, rank, nodeReg=None) -> Optional[str]:
         try:
             nym = self.node_ids_ordered_by_rank(nodeReg)[rank]
@@ -531,6 +566,9 @@ class RegistryPoolManager(PoolManager):
     def get_rank_of(self, node_id, nodeReg=None) -> Optional[int]:
         # TODO node_id here has got another meaning
         return self._get_rank(node_id, self.node_names_ordered_by_rank(nodeReg))
+
+    def get_rank_by_name(self, name, nodeReg=None) -> Optional[int]:
+        return self.get_rank_of(name, nodeReg)
 
     def get_name_by_rank(self, rank, nodeReg=None) -> Optional[str]:
         try:

--- a/plenum/server/view_change/view_changer.py
+++ b/plenum/server/view_change/view_changer.py
@@ -144,7 +144,7 @@ class ViewChanger(HasActionQueue, MessageProcessor):
     @property
     def has_view_change_from_primary(self) -> bool:
         if not self._has_view_change_from_primary:
-            next_primary_name = self.node.elector.next_primary_node_name(0)
+            next_primary_name = self.node.elector._next_primary_node_name_for_master()
 
             if next_primary_name not in self._view_change_done:
                 logger.debug(
@@ -579,7 +579,7 @@ class ViewChanger(HasActionQueue, MessageProcessor):
         This method is called when sufficient number of ViewChangeDone
         received and makes steps to switch to the new primary
         """
-        expected_primary = self.node.elector.next_primary_node_name(0)
+        expected_primary = self.node.elector._next_primary_node_name_for_master()
         if new_primary != expected_primary:
             logger.error("{}{} expected next primary to be {}, but majority "
                          "declared {} instead for view {}"
@@ -595,7 +595,7 @@ class ViewChanger(HasActionQueue, MessageProcessor):
         """
         Sends ViewChangeDone message to other protocol participants
         """
-        new_primary_name = self.node.elector.next_primary_node_name(0)
+        new_primary_name = self.node.elector._next_primary_node_name_for_master()
         ledger_summary = self.node.ledger_summary
         message = ViewChangeDone(self.view_no,
                                  new_primary_name,

--- a/plenum/test/pool_transactions/helper.py
+++ b/plenum/test/pool_transactions/helper.py
@@ -144,11 +144,13 @@ def start_not_added_node(looper,
                                          tdir, randomString(32).encode(),
                                          (nodeIp, nodePort), (clientIp, clientPort),
                                          tconf, True, allPluginsPath, TestNode)
-    return sigseed, bls_key, new_node
+    return sigseed, bls_key, new_node, (nodeIp, nodePort), (clientIp, clientPort)
 
 
 def add_started_node(looper,
                      new_node,
+                     node_ha,
+                     client_ha,
                      txnPoolNodeSet,
                      client_tdir,
                      stewardClient, stewardWallet,
@@ -165,10 +167,10 @@ def add_started_node(looper,
                                                  clientClass=TestClient)
     node_name = new_node.name
     send_new_node_txn(sigseed,
-                      new_node.poolManager.nodeReg[node_name][0],
-                      new_node.poolManager.nodeReg[node_name][1],
-                      new_node.poolManager.cliNodeReg[node_name + "C"][0],
-                      new_node.poolManager.cliNodeReg[node_name + "C"][1],
+                      node_ha[0],
+                      node_ha[1],
+                      client_ha[0],
+                      client_ha[1],
                       bls_key,
                       node_name,
                       newSteward, newStewardWallet)

--- a/plenum/test/primary_selection/test_primary_selection_after_primary_demotion_and_promotion.py
+++ b/plenum/test/primary_selection/test_primary_selection_after_primary_demotion_and_promotion.py
@@ -1,0 +1,61 @@
+from plenum.common.constants import ALIAS, SERVICES, VALIDATOR
+from plenum.test.pool_transactions.conftest import looper
+from plenum.test.pool_transactions.helper import updateNodeData
+
+from plenum.test.test_node import ensureElectionsDone
+from plenum.test.helper import sendReqsToNodesAndVerifySuffReplies
+
+from plenum.test.primary_selection.helper import getPrimaryNodesIdxs
+
+
+def test_primary_selection_after_demoted_primary_node_promotion(
+        looper, txnPoolNodeSet, stewardAndWalletForMasterNode,
+        txnPoolMasterNodes):
+    """
+    Demote primary of master instance, wait for view change and promote it back.
+    Check primaries for instances.
+    """
+    assert len(txnPoolNodeSet) == 4
+
+    # Check primaries after test setup.
+    primariesIdxs = getPrimaryNodesIdxs(txnPoolNodeSet)
+    assert len(primariesIdxs) == 2
+    assert primariesIdxs[0] == 0
+    assert primariesIdxs[1] == 1
+
+    master_node = txnPoolMasterNodes[0]
+    client, wallet = stewardAndWalletForMasterNode
+
+    # Demote primary of master instance.
+    node_data = {
+        ALIAS: master_node.name,
+        SERVICES: []
+    }
+    updateNodeData(looper, client, wallet, master_node, node_data)
+
+    restNodes = [node for node in txnPoolNodeSet if node.name != master_node.name]
+    ensureElectionsDone(looper, restNodes)
+
+    # Check that there is only one instance now, check it's primary.
+    primariesIdxs = getPrimaryNodesIdxs(restNodes)
+    assert len(primariesIdxs) == 1
+    assert primariesIdxs[0] == 1
+
+    # Ensure pool is working properly.
+    sendReqsToNodesAndVerifySuffReplies(looper, wallet, client, numReqs=3)
+
+    # Promote demoted node back.
+    node_data = {
+        ALIAS: master_node.name,
+        SERVICES: [VALIDATOR]
+    }
+    updateNodeData(looper, client, wallet, master_node, node_data)
+
+    # Ensure pool is working properly.
+    sendReqsToNodesAndVerifySuffReplies(looper, wallet, client, numReqs=3)
+
+    # Check that there are two instances again, check their primaries.
+    primariesIdxs = getPrimaryNodesIdxs(txnPoolNodeSet)
+    assert len(primariesIdxs) == 2
+    assert primariesIdxs[0] == 2
+    assert primariesIdxs[1] == 3

--- a/plenum/test/primary_selection/test_primary_selector.py
+++ b/plenum/test/primary_selection/test_primary_selector.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from contextlib import ExitStack
 
 import base58
 import pytest
@@ -12,7 +13,9 @@ from plenum.common.messages.node_messages import ViewChangeDone
 from plenum.server.quorums import Quorums
 from plenum.server.replica import Replica
 from plenum.common.ledger_manager import LedgerManager
-from plenum.common.config_util import getConfig
+from plenum.common.config_util import getConfigOnce
+from plenum.test.helper import create_new_test_node
+from plenum.test.test_node import TestNode
 
 
 whitelist = ['but majority declared']
@@ -32,7 +35,7 @@ class FakeLedger:
 class FakeNode:
     ledger_ids = [0]
 
-    def __init__(self, tmpdir):
+    def __init__(self, tmpdir, config=None):
         self.basedirpath = tmpdir
         self.name = 'Node1'
         self.f = 1
@@ -44,10 +47,11 @@ class FakeNode:
         }
         self.totalNodes = len(self.allNodeNames)
         self.mode = Mode.starting
+        self.config = config or getConfigOnce()
         self.replicas = [
-            Replica(node=self, instId=0, isMaster=True),
-            Replica(node=self, instId=1, isMaster=False),
-            Replica(node=self, instId=2, isMaster=False),
+            Replica(node=self, instId=0, isMaster=True, config=self.config),
+            Replica(node=self, instId=1, isMaster=False, config=self.config),
+            Replica(node=self, instId=2, isMaster=False, config=self.config),
         ]
         self._found = False
         self.ledgerManager = LedgerManager(self, ownedByNode=True)
@@ -56,7 +60,6 @@ class FakeNode:
         self.ledgerManager.addLedger(0, ledger0)
         self.ledgerManager.addLedger(1, ledger1)
         self.quorums = Quorums(self.totalNodes)
-        self.config = getConfig() # TODO do we need fake object here?
         self.view_changer = ViewChanger(self)
         self.elector = PrimarySelector(self)
 
@@ -100,7 +103,7 @@ class FakeNode:
     def start_catchup(self):
         pass
 
-def test_has_view_change_quorum_number(tmpdir):
+def test_has_view_change_quorum_number(tconf, tdir):
     """
     Checks method _hasViewChangeQuorum of SimpleSelector
     It must have n-f ViewChangeDone
@@ -114,7 +117,7 @@ def test_has_view_change_quorum_number(tmpdir):
         (1, 5, 'Hs9n4M3CrmrkWGVviGq48vSbMpCrk6WgSBZ7sZAWbJy3')
     )
 
-    node = FakeNode(str(tmpdir))
+    node = FakeNode(str(tdir), tconf)
     node.view_changer.view_change_in_progress = True
     node.view_changer.propagate_primary = False
 
@@ -138,7 +141,7 @@ def test_has_view_change_quorum_number(tmpdir):
     assert node.view_changer._hasViewChangeQuorum
 
 
-def test_has_view_change_quorum_must_contain_primary(tmpdir):
+def test_has_view_change_quorum_must_contain_primary(tconf, tdir):
     """
     Checks method _hasViewChangeQuorum of SimpleSelector
     It must have n-f ViewChangeDone including a VCD from the next Primary
@@ -152,7 +155,7 @@ def test_has_view_change_quorum_must_contain_primary(tmpdir):
         (1, 5, 'Hs9n4M3CrmrkWGVviGq48vSbMpCrk6WgSBZ7sZAWbJy3')
     )
 
-    node = FakeNode(str(tmpdir))
+    node = FakeNode(str(tdir), tconf)
     node.view_changer.view_change_in_progress = True
     node.view_changer.propagate_primary = False
 
@@ -181,7 +184,7 @@ def test_has_view_change_quorum_must_contain_primary(tmpdir):
     assert node.view_changer.has_view_change_from_primary
 
 
-def test_has_view_change_quorum_number_propagate_primary(tmpdir):
+def test_has_view_change_quorum_number_propagate_primary(tconf, tdir):
     """
     Checks method _hasViewChangeQuorum of SimpleSelector
     It must have f+1 ViewChangeDone in the case of PrimaryPropagation
@@ -195,7 +198,7 @@ def test_has_view_change_quorum_number_propagate_primary(tmpdir):
         (1, 5, 'Hs9n4M3CrmrkWGVviGq48vSbMpCrk6WgSBZ7sZAWbJy3')
     )
 
-    node = FakeNode(str(tmpdir))
+    node = FakeNode(str(tdir), tconf)
     node.view_changer.view_change_in_progress = True
     node.view_changer.propagate_primary = True
 
@@ -216,7 +219,7 @@ def test_has_view_change_quorum_number_propagate_primary(tmpdir):
     assert node.view_changer.has_view_change_from_primary
 
 
-def test_has_view_change_quorum_number_must_contain_primary_propagate_primary(tmpdir):
+def test_has_view_change_quorum_number_must_contain_primary_propagate_primary(tconf, tdir):
     """
     Checks method _hasViewChangeQuorum of SimpleSelector
     It must have f+1 ViewChangeDone and contain a VCD from the next Primary in the case of PrimaryPropagation
@@ -230,7 +233,7 @@ def test_has_view_change_quorum_number_must_contain_primary_propagate_primary(tm
         (1, 5, 'Hs9n4M3CrmrkWGVviGq48vSbMpCrk6WgSBZ7sZAWbJy3')
     )
 
-    node = FakeNode(str(tmpdir))
+    node = FakeNode(str(tdir), tconf)
     node.view_changer.view_change_in_progress = True
     node.view_changer.propagate_primary = True
 
@@ -255,7 +258,7 @@ def test_has_view_change_quorum_number_must_contain_primary_propagate_primary(tm
     assert node.view_changer._hasViewChangeQuorum
 
 
-def test_process_view_change_done(tmpdir):
+def test_process_view_change_done(tdir, tconf):
     ledgerInfo = (
         # ledger id, ledger length, merkle root
         (0, 10, '7toTJZHzaxQ7cGZv18MR4PMBfuUecdEQ1JRqJVeJBvmd'),
@@ -264,7 +267,7 @@ def test_process_view_change_done(tmpdir):
     msg = ViewChangeDone(viewNo=0,
                          name='Node2',
                          ledgerInfo=ledgerInfo)
-    node = FakeNode(str(tmpdir))
+    node = FakeNode(str(tdir), tconf)
     quorum = node.view_changer.quorum
     for i in range(quorum):
         node.view_changer.process_vchd_msg(msg, 'Node2')
@@ -285,7 +288,7 @@ def test_process_view_change_done(tmpdir):
     assert not node.view_changer._view_change_done
 
 
-def test_get_msgs_for_lagged_nodes(tmpdir):
+def test_get_msgs_for_lagged_nodes(tconf, tdir):
     ledgerInfo = (
         #  ledger id, ledger length, merkle root
         (0, 10, '7toTJZHzaxQ7cGZv18MR4PMBfuUecdEQ1JRqJVeJBvmd'),
@@ -302,7 +305,7 @@ def test_get_msgs_for_lagged_nodes(tmpdir):
             name='Node3',
             ledgerInfo=ledgerInfo),
          'Node2')]
-    node = FakeNode(str(tmpdir))
+    node = FakeNode(str(tdir), tconf)
     for message in messages:
         node.view_changer.process_vchd_msg(*message)
 
@@ -311,12 +314,11 @@ def test_get_msgs_for_lagged_nodes(tmpdir):
         m[0] for m in messages if m[1] == node.name}
 
 
-def test_send_view_change_done_message(tmpdir):
-    node = FakeNode(str(tmpdir))
-    instance_id = 0
+def test_send_view_change_done_message(tdir, tconf):
+    node = FakeNode(str(tdir), tconf)
     view_no = node.view_changer.view_no
-    new_primary_name = node.elector.node.get_name_by_rank(node.elector._get_primary_id(
-        view_no, instance_id, node.totalNodes))
+    new_primary_name = node.elector.node.get_name_by_rank(node.elector._get_master_primary_id(
+        view_no, node.totalNodes))
     node.view_changer._send_view_change_done_message()
 
     ledgerInfo = [
@@ -334,3 +336,151 @@ def test_send_view_change_done_message(tmpdir):
     print(messages)
 
     assert list(node.view_changer.outBox) == messages
+
+
+nodeCount = 7
+
+
+@pytest.fixture(scope="module")
+def txnPoolNodeSetWithElector(node_config_helper_class,
+                              patchPluginManager,
+                              tdirWithPoolTxns,
+                              tdirWithDomainTxns,
+                              tdir,
+                              tconf,
+                              poolTxnNodeNames,
+                              allPluginsPath,
+                              tdirWithNodeKeepInited,
+                              testNodeClass,
+                              do_post_node_creation):
+    with ExitStack() as exitStack:
+        nodes = []
+        for nm in poolTxnNodeNames:
+            node = exitStack.enter_context(create_new_test_node(
+                testNodeClass, node_config_helper_class, nm, tconf, tdir,
+                allPluginsPath))
+            do_post_node_creation(node)
+            nodes.append(node)
+        assert len(nodes) == 7
+        for node in nodes:
+            node.view_changer = node.newViewChanger()
+            node.elector = node.newPrimaryDecider()
+        yield nodes
+
+
+def test_primaries_selection_viewno_0(txnPoolNodeSetWithElector):
+    view_no = 0
+
+    for node in txnPoolNodeSetWithElector:
+        assert node.replicas.num_replicas == 3
+        primaries = set()
+        view_no_bak = node.elector.viewNo
+        node.elector.viewNo = view_no
+        name, instance_name = node.elector.next_primary_replica_name_for_master(node.nodeReg)
+        master_primary_rank = node.poolManager.get_rank_by_name(name)
+        assert master_primary_rank == 0
+        assert name == "Alpha" and instance_name == "Alpha:0"
+        primaries.add(name)
+
+        instance_id = 1
+        name, instance_name = node.elector.next_primary_replica_name_for_backup(
+            instance_id, master_primary_rank, primaries)
+        primary_rank = node.poolManager.get_rank_by_name(name)
+        assert primary_rank == 1
+        assert name == "Beta" and instance_name == "Beta:1"
+        primaries.add(name)
+
+        instance_id = 2
+        name, instance_name = node.elector.next_primary_replica_name_for_backup(
+            instance_id, master_primary_rank, primaries)
+        primary_rank = node.poolManager.get_rank_by_name(name)
+        assert primary_rank == 2
+        assert name == "Gamma" and instance_name == "Gamma:2"
+        primaries.add(name)
+
+        node.elector.viewNo = view_no_bak
+
+
+def test_primaries_selection_viewno_5(txnPoolNodeSetWithElector):
+    view_no = 5
+
+    for node in txnPoolNodeSetWithElector:
+        assert node.replicas.num_replicas == 3
+        primaries = set()
+        view_no_bak = node.elector.viewNo
+        node.elector.viewNo = view_no
+        name, instance_name = node.elector.next_primary_replica_name_for_master(node.nodeReg)
+        master_primary_rank = node.poolManager.get_rank_by_name(name)
+        assert master_primary_rank == 5
+        assert name == "Zeta" and instance_name == "Zeta:0"
+        primaries.add(name)
+
+        instance_id = 1
+        name, instance_name = node.elector.next_primary_replica_name_for_backup(
+            instance_id, master_primary_rank, primaries)
+        primary_rank = node.poolManager.get_rank_by_name(name)
+        assert primary_rank == 6
+        assert name == "Eta" and instance_name == "Eta:1"
+        primaries.add(name)
+
+        instance_id = 2
+        name, instance_name = node.elector.next_primary_replica_name_for_backup(
+            instance_id, master_primary_rank, primaries)
+        primary_rank = node.poolManager.get_rank_by_name(name)
+        assert primary_rank == 0
+        assert name == "Alpha" and instance_name == "Alpha:2"
+        primaries.add(name)
+
+        node.elector.viewNo = view_no_bak
+
+
+def test_primaries_selection_viewno_9(txnPoolNodeSetWithElector):
+    view_no = 9
+
+    for node in txnPoolNodeSetWithElector:
+        assert node.replicas.num_replicas == 3
+        primaries = set()
+        view_no_bak = node.elector.viewNo
+        node.elector.viewNo = view_no
+        name, instance_name = node.elector.next_primary_replica_name_for_master(node.nodeReg)
+        master_primary_rank = node.poolManager.get_rank_by_name(name)
+        assert master_primary_rank == 2
+        assert name == "Gamma" and instance_name == "Gamma:0"
+        primaries.add(name)
+
+        instance_id = 1
+        name, instance_name = node.elector.next_primary_replica_name_for_backup(
+            instance_id, master_primary_rank, primaries)
+        primary_rank = node.poolManager.get_rank_by_name(name)
+        assert primary_rank == 3
+        assert name == "Delta" and instance_name == "Delta:1"
+        primaries.add(name)
+
+        instance_id = 2
+        name, instance_name = node.elector.next_primary_replica_name_for_backup(
+            instance_id, master_primary_rank, primaries)
+        primary_rank = node.poolManager.get_rank_by_name(name)
+        assert primary_rank == 4
+        assert name == "Epsilon" and instance_name == "Epsilon:2"
+        primaries.add(name)
+
+        node.elector.viewNo = view_no_bak
+
+
+def test_primaries_selection_gaps(txnPoolNodeSetWithElector):
+    for node in txnPoolNodeSetWithElector:
+        assert node.replicas.num_replicas == 3
+        """
+        The gaps between primary nodes may occur due to nodes demotion and promotion
+        with changed number of instances. These gaps should be filled by new
+        primaries during primary selection for new backup instances created as
+        a result of instances growing.
+        """
+        primary_0 = "Beta"
+        primary_1 = "Delta"
+        primaries = {primary_0, primary_1}
+        master_primary_rank = node.poolManager.get_rank_by_name(primary_0)
+        name, instance_name = node.elector.next_primary_replica_name_for_backup(
+            2, master_primary_rank, primaries)
+        assert name == "Gamma" and \
+            instance_name == "Gamma:2"

--- a/plenum/test/view_change/test_no_instance_change_before_node_is_ready.py
+++ b/plenum/test/view_change/test_no_instance_change_before_node_is_ready.py
@@ -35,9 +35,10 @@ def test_no_instance_change_on_primary_disconnection_for_not_ready_node(
     """
 
     # 1. create a new node, but don't add it to the pool (so not send NODE txn), so that the node is not ready.
-    sigseed, bls_key, new_node = start_not_added_node(looper,
-                                                      tdir, tconf, allPluginsPath,
-                                                      "TestTheta")
+    sigseed, bls_key, new_node, node_ha, client_ha = \
+        start_not_added_node(looper,
+                             tdir, tconf, allPluginsPath,
+                             "TestTheta")
 
     # 2. wait for more than VIEW_CHANGE_TIMEOUT (a timeout for initial check for disconnected primary)
     looper.runFor(tconf.VIEW_CHANGE_TIMEOUT + 2)
@@ -48,6 +49,8 @@ def test_no_instance_change_on_primary_disconnection_for_not_ready_node(
     # 4. add the node to the pool (send NODE txn) and make sure that the node is ready now.
     add_started_node(looper,
                      new_node,
+                     node_ha,
+                     client_ha,
                      txnPoolNodeSet,
                      client_tdir,
                      steward1, stewardWallet,

--- a/plenum/test/view_change/test_view_change_timeout.py
+++ b/plenum/test/view_change/test_view_change_timeout.py
@@ -96,7 +96,7 @@ def test_view_change_timeout_next_primary_is_disconnected(nodeSet, looper, up, s
 
 
 def stop_next_primary(nodes):
-    m_next_primary_name = nodes[0]._elector.next_primary_node_name(0)
+    m_next_primary_name = nodes[0]._elector._next_primary_node_name_for_master()
     nodes[m_next_primary_name].stop()
     alive_nodes = list(filter(lambda x: x.name != m_next_primary_name, nodes))
     return alive_nodes


### PR DESCRIPTION
…(#539)

* INDY-1112: change primeries election procedure for backup instances.

Now primaries for backup instances are choosen in round-robin
manner always starting from primary. If the next node is a primary
for some instance then this node is skipped. So the first non-primary
node is choosen as primary for current instance. Such approach allows
to avoid election of instances of the same node as a primeries for
different instances.
The election procedure of the primary for master instance is not changed.

Signed-off-by: Sergey Shilov <sergey.shilov@dsr-company.com>

* Add some stylistical fixes, add comments.

Signed-off-by: Sergey Shilov <sergey.shilov@dsr-company.com>

* Add test for primary demotion and promotion.

Signed-off-by: Sergey Shilov <sergey.shilov@dsr-company.com>

* Add test for primaries selection routines.

Signed-off-by: Sergey Shilov <sergey.shilov@dsr-company.com>

* Re-factor primary selector tests.

Signed-off-by: Sergey Shilov <sergey.shilov@dsr-company.com>

* Remove adding of node itself to nodeReg during initialisation of txnPoolManager.

Now a node adds itself to nodeReg during catch-up of pool ledger.

Signed-off-by: Sergey Shilov <sergey.shilov@dsr-company.com>

* Fix test.

Signed-off-by: Sergey Shilov <sergey.shilov@dsr-company.com>

* Update node's HA in node registry on pool ledger catch-up reply.

Signed-off-by: Sergey Shilov <sergey.shilov@dsr-company.com>

* Add separate checks for IP/port to be updated for HA and cliHA.

Signed-off-by: Sergey Shilov <sergey.shilov@dsr-company.com>